### PR TITLE
Command updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,6 @@ dotnet_naming_style.underscore_camel_case_style.required_prefix = _
 dotnet_naming_style.interface_pascal_case.capitalization = pascal_case
 dotnet_naming_style.interface_pascal_case.required_prefix = I
 
-
 # Constants are to be styles as PascalCase
 dotnet_naming_rule.constants_pascal_cased.symbols = constant_symbols
 
@@ -32,10 +31,10 @@ dotnet_naming_symbols.non_field_symbols.applicable_accessibilities = *
 dotnet_naming_rule.non_fields_pascal_cased.style = pascal_case_style
 dotnet_naming_rule.non_fields_pascal_cased.severity = suggestion
 
-# Private fields are to be styled as _camelCase
+# Private fields and events are to be styled as _camelCase
 dotnet_naming_rule.private_fields_camel_cased.symbols = private_field_symbols
 
-dotnet_naming_symbols.private_field_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_field_symbols.applicable_kinds = field, event
 dotnet_naming_symbols.private_field_symbols.applicable_accessibilities = private
 
 dotnet_naming_rule.private_fields_camel_cased.style = underscore_camel_case_style

--- a/CoreMVVM/Input/ICommandExt.cs
+++ b/CoreMVVM/Input/ICommandExt.cs
@@ -1,6 +1,6 @@
 ﻿using System.Windows.Input;
 
-namespace CoreMVVM
+namespace CoreMVVM.Input
 {
     /// <summary>
     /// An extension of the <see cref="ICommand"/> interface.

--- a/CoreMVVM/Input/ICommand{T}.cs
+++ b/CoreMVVM/Input/ICommand{T}.cs
@@ -1,0 +1,21 @@
+﻿using System.Windows.Input;
+
+namespace CoreMVVM.Input
+{
+    /// <summary>
+    /// A generic extension of <see cref="ICommand"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the parameter of this command.</typeparam>
+    public interface ICommand<T> : ICommandExt
+    {
+        /// <summary>
+        /// Returns a value indicating if this command can be executed.
+        /// </summary>
+        bool CanExecute(T parameter);
+
+        ///<summary>
+        /// Executes this command.
+        ///</summary>
+        void Execute(T parameter);
+    }
+}

--- a/CoreMVVM/Input/NullCommand.cs
+++ b/CoreMVVM/Input/NullCommand.cs
@@ -19,9 +19,9 @@ namespace CoreMVVM.Input
 
         event EventHandler ICommand.CanExecuteChanged { add { } remove { } }
 
-        bool ICommand.CanExecute(object parameter) => true;
+        bool ICommand.CanExecute(object? parameter) => true;
 
-        void ICommand.Execute(object parameter)
+        void ICommand.Execute(object? parameter)
         { }
     }
 }

--- a/CoreMVVM/Input/NullCommand.cs
+++ b/CoreMVVM/Input/NullCommand.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Windows.Input;
 
-namespace CoreMVVM
+namespace CoreMVVM.Input
 {
     /// <summary>
     /// An empty command.

--- a/CoreMVVM/Input/RelayCommand{T}.cs
+++ b/CoreMVVM/Input/RelayCommand{T}.cs
@@ -6,7 +6,7 @@ namespace CoreMVVM.Input
     /// <summary>
     /// A default generic implementation of <see cref="ICommand"/>.
     /// </summary>
-    public class RelayCommand<T> : ICommandExt
+    public class RelayCommand<T> : ICommand<T>
     {
 #pragma warning disable CA1000 // Do not declare static members on generic types
 


### PR DESCRIPTION
- Updated nullability on `RelayCommand<T>`'s implementation of `ICommand`.
- Added generic `ICommand<T>` that extends `ICommandExt`
- Moved `ICommandExt` and `NullCommand` to `CoreMVVM.Input`